### PR TITLE
Arrumando link do footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
 				</div>
 				<nav class="footer__nav">
 					<a href="" class="footer__link">Home</a>
-					<a href="" class="footer__link">Serviços</a>
+					<a href="" class="footer__link">Sobre nós</a>
 					<a href="" class="footer__link">Contato</a>
 				</nav>
 				<div class="footer__social">


### PR DESCRIPTION
Antes o link do footer estava com o texto de uma página "serviços", que não existe na regra de negócio do projeto. Foi trocado para "Sobre nós".